### PR TITLE
Fix Python3 module, various GCC warnings and Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ chooch : clean ${OBJECTS} Makefile
 	$(CC) -o ${EXE} ${CFLAGS} ${OBJECTS} $(LDFLAGS)
 
 pychooch : clean ${OBJECTS} 
-	$(CC) -shared -o ./$(OSTYPE)/PyChooch.so PyChooch.c ${PYOBJECTS} -I/segfs/bliss/depot/pythonbliss/installdir/$(OSTYPE)/python-2.5.2/include/python2.5/ $(LDFLAGS)
+	$(CC) -shared -o ./$(OSTYPE)/PyChooch.so PyChooch.c ${CFLAGS} ${PYOBJECTS} $(LDFLAGS)
 
 chooch-pg : 
 	make chooch-with-pgplot "CFLAGS = -I$(INCLUDE) $(CFLAGS) -DPGPLOT"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ PGPLOTDIR  = /usr/local/pgplot
 DISLIN = /usr/local/dislin
 GSLDIR = /usr/local/lib
 CGRAPHDIR = /usr/local/lib
-BINDIR    = /home/gwyndaf/bin
 INCLUDE   = /usr/local/pgplot
 X11LIBDIR  = /usr/X11R6/lib
 ######################################
@@ -27,6 +26,10 @@ PGLIBS =  -lcpgplot -lpgplot
 DISLINLIBS= -ldislnc
 EXE    = chooch-$(VERSION).$(ARCH)
 EXEPG    = chooch-$(VERSION)-pg.$(ARCH)
+
+PYTHON_INCLUDE_DIR ?= $(shell python -c 'from distutils.sysconfig import get_python_inc; print(get_python_inc())')
+PYTHON_DEST_DIR ?= $(shell python -c 'import site; print(site.getsitepackages()[0])')
+
 #
 # How to compile and link
 #
@@ -58,7 +61,7 @@ chooch : clean ${OBJECTS} Makefile
 	$(CC) -o ${EXE} ${CFLAGS} ${OBJECTS} $(LDFLAGS)
 
 pychooch : clean ${OBJECTS} 
-	$(CC) -shared -o ./$(OSTYPE)/PyChooch.so PyChooch.c ${CFLAGS} ${PYOBJECTS} $(LDFLAGS)
+	$(CC) -shared -o PyChooch.so PyChooch.c ${CFLAGS} ${PYOBJECTS} $(LDFLAGS)
 
 chooch-pg : 
 	make chooch-with-pgplot "CFLAGS = -I$(INCLUDE) $(CFLAGS) -DPGPLOT"
@@ -68,9 +71,8 @@ chooch-with-pgplot : clean ${OBJECTS} Makefile
 #
 all: chooch chooch-pg
 #
-install :
-	$(MV) $(EXE)   $(BINDIR)
-	$(MV) $(EXEPG) $(BINDIR)
+install : pychooch
+	$(MV) PyChooch.so $(PYTHON_DEST_DIR)
 #
 clean :
 	${RM} -f *.o

--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -1,8 +1,2 @@
-FOPTIM = -O2
-FFLAGS = $(FOPTIM)
-#LDFLAGS = -static -L$(PGPLOTDIR) $(PGLIBS) -L$(X11LIBDIR) -L$(GSLDIR) \
-#	-L$(CGRAPHDIR) -L$(DISLIN) $(DISLINLIBS) $(CGRAPH) $(LIBS) -lm -ldl -lpthread
-LDFLAGS=-L$(GSLDIR) $(LIBS) -lm -ldl -lpthread -L$(CONDA_PREFIX)/lib -L$(CONDA_PREFIX)/lib
-CFLAGS = -fPIC -I$(CONDA_PREFIX)/include -I$(CONDA_PREFIX)/include/python3.7m
-FC     = g77
-CC     = gcc
+LDFLAGS = $(LIBS) -lm -ldl -lpthread -L$(PREFIX)/lib
+CFLAGS = -fPIC -I$(PREFIX)/include -I$(PYTHON_INCLUDE_DIR)

--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -2,7 +2,7 @@ FOPTIM = -O2
 FFLAGS = $(FOPTIM)
 #LDFLAGS = -static -L$(PGPLOTDIR) $(PGLIBS) -L$(X11LIBDIR) -L$(GSLDIR) \
 #	-L$(CGRAPHDIR) -L$(DISLIN) $(DISLINLIBS) $(CGRAPH) $(LIBS) -lm -ldl -lpthread
-LDFLAGS=-L$(GSLDIR) $(LIBS) -lm -ldl -lpthread
-CFLAGS = -static
+LDFLAGS=-L$(GSLDIR) $(LIBS) -lm -ldl -lpthread -L$(CONDA_PREFIX)/lib -L$(CONDA_PREFIX)/lib
+CFLAGS = -fPIC -I$(CONDA_PREFIX)/include -I$(CONDA_PREFIX)/include/python3.7m
 FC     = g77
 CC     = gcc

--- a/PyChooch.c
+++ b/PyChooch.c
@@ -7,6 +7,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
+
+#include <gsl/gsl_errno.h>
+
 #include "chooch.h"
 
 char *sElement;
@@ -114,12 +117,23 @@ void custom_err_handler(const char* reason, const char* file, int line, int gsl_
 
 
 PyMODINIT_FUNC
-initPyChooch(void)
+PyInit_PyChooch(void)
 {
     // install our own error handler for the GSL
     gsl_set_error_handler(&custom_err_handler);	
 
-    (void) Py_InitModule("PyChooch", PyChoochMethods);
+    //(void) Py_InitModule("PyChooch", PyChoochMethods);
+    
+    static struct PyModuleDef cModPyDem =
+    {
+        PyModuleDef_HEAD_INIT,
+        "PyChooch", /* name of module */
+        "",          /* module documentation, may be NULL */
+        -1,          /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+        PyChoochMethods
+    };
+    
+    PyModule_Create(&cModPyDem);
 }
 
 static int my_efswrite(const char *filename, double *x, double *y1, double *y2, int n) {
@@ -259,5 +273,3 @@ PyObject* chooch_calc(double *fXraw, double *fYraw, int nDataPoints, const char*
 
   return res;
 }
-
-

--- a/main.c
+++ b/main.c
@@ -31,6 +31,13 @@
 #include <math.h>
 //
 #include "chooch.h"
+
+//Forward definition
+void license();
+void nowarranty();
+void distribution();
+
+
 int c;
 char  *sElement="Se";           // Letter symbol for element name e.g. Au, Se, I
 char cScanTitle[TITLE]="";
@@ -146,15 +153,15 @@ int main(int argc, char *argv[])
 	if(!silent)printf("-d: Dump data file for pooch\n", fE4);
 	break;
      case 'w' :
-	(void)nowarranty();
+	nowarranty();
 	exit(EXIT_SUCCESS);
 	break;
      case 'c' :
-	(void)distribution();
+	distribution();
 	exit(EXIT_SUCCESS);
 	break;
      case 'l' :
-	(void)license();
+	license();
 	exit(EXIT_SUCCESS);
 	break;
      }  

--- a/test_pychooch.py
+++ b/test_pychooch.py
@@ -7,7 +7,7 @@ def main():
     with open(filename) as f:
         for _ in range(2):
             next(f)
-        data = [map(float, line.split()) for line in f]
+        data = [list(map(float, line.split())) for line in f]
     result = PyChooch.calc(data, "Se", "K")
     print(result)
 

--- a/usage.c
+++ b/usage.c
@@ -15,6 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
+
 #include "chooch.h"
 void usage()
 {


### PR DESCRIPTION
This will probably requires further improvements to make it a Conda package.

- [ ] Improve build system to make it Conda compatible (e.g. use `$CC` and other env variables) rather than hardcoded values
- [ ] Write a conda recipe